### PR TITLE
Add calling super-range builder and writer

### DIFF
--- a/src/Poker.RangeApprox.App/Program.cs
+++ b/src/Poker.RangeApprox.App/Program.cs
@@ -1,6 +1,5 @@
 ﻿using Poker.RangeApprox.Core.Approximation;
 using Poker.RangeApprox.Core.Domain;
-using Poker.RangeApprox.Core.Formatting;
 using Poker.RangeApprox.Infrastructure.Parsing;
 using Poker.RangeApprox.Infrastructure.Writing;
 
@@ -53,6 +52,8 @@ var engine = new ApproximationEngine(
     partitionApproximator);
 
 var writer = new RangeFileWriter();
+var callingSuperRangeBuilder = new CallingSuperRangeBuilder();
+var weightedSuperRangeWriter = new WeightedSuperRangeFileWriter(writer);
 
 switch (mode)
 {
@@ -132,6 +133,19 @@ void RunAll(List<PopulationNode> populationNodes)
 
         Write(node, result);
     }
+
+    var callingSuperRanges = callingSuperRangeBuilder.Build(populationNodes, results);
+    weightedSuperRangeWriter.WriteAll("output", callingSuperRanges);
+
+    Console.WriteLine($"Generating {callingSuperRanges.Count} weighted calling super-ranges");
+    Console.WriteLine();
+
+    foreach (var superRange in callingSuperRanges.Values.OrderBy(x => x.OpenPosition, StringComparer.OrdinalIgnoreCase))
+    {
+        Console.WriteLine($"Super-range: {superRange.Key}");
+        Console.WriteLine($"Output: {Path.Combine("output", "calling super-ranges", superRange.Key)}");
+        Console.WriteLine();
+    }
 }
 
 void Write(PopulationNode node, ApproximationResult result)
@@ -139,7 +153,7 @@ void Write(PopulationNode node, ApproximationResult result)
     var (directory, fileName) = GetOutputPath(node.NodeId);
 
     writer.WriteEquilab(Path.Combine(directory, $"{fileName}.txt"), result.Cells);
-    if(false)   writer.WriteMatrix(Path.Combine(directory, $"{fileName}_matrix.txt"), result.Cells);
+    if (false) writer.WriteMatrix(Path.Combine(directory, $"{fileName}_matrix.txt"), result.Cells);
 
     Console.WriteLine($"Node: {node.NodeId.ToKey()}");
     Console.WriteLine($"Output: {Path.Combine(directory, fileName)}");
@@ -152,9 +166,6 @@ void Write(PopulationNode node, ApproximationResult result)
     var actor = nodeId.Actor.Trim().ToLowerInvariant();
     var opponent = nodeId.Opponent?.Trim().ToLowerInvariant();
 
-    // -------------------------
-    // RFI
-    // -------------------------
     if (action == "rfi")
     {
         return (
@@ -163,9 +174,6 @@ void Write(PopulationNode node, ApproximationResult result)
         );
     }
 
-    // -------------------------
-    // Facing open
-    // -------------------------
     if (action is "call" or "fold" or "threebet")
     {
         if (!string.IsNullOrWhiteSpace(opponent) &&
@@ -180,9 +188,6 @@ void Write(PopulationNode node, ApproximationResult result)
         }
     }
 
-    // -------------------------
-    // Facing 3bet
-    // -------------------------
     if (action == "fourbet")
     {
         return (

--- a/src/Poker.RangeApprox.Core/Approximation/CallingSuperRangeBuilder.cs
+++ b/src/Poker.RangeApprox.Core/Approximation/CallingSuperRangeBuilder.cs
@@ -1,0 +1,124 @@
+﻿using Poker.RangeApprox.Core.Domain;
+
+namespace Poker.RangeApprox.Core.Approximation;
+
+public sealed class CallingSuperRangeBuilder
+{
+    public IReadOnlyDictionary<string, WeightedSuperRangeResult> Build(
+        IEnumerable<PopulationNode> sourceNodes,
+        IReadOnlyDictionary<string, ApproximationResult> approximationResults)
+    {
+        ArgumentNullException.ThrowIfNull(sourceNodes);
+        ArgumentNullException.ThrowIfNull(approximationResults);
+
+        var callVsOpenNodes = sourceNodes
+            .Where(IsCallVsOpenNode)
+            .ToList();
+
+        var groupedByOpenPosition = callVsOpenNodes
+            .GroupBy(
+                n => NormalizeOpponent(n.NodeId.Opponent!),
+                StringComparer.OrdinalIgnoreCase);
+
+        var results = new Dictionary<string, WeightedSuperRangeResult>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var group in groupedByOpenPosition)
+        {
+            var openPosition = group.Key;
+            var sourceRangeCount = group.Count();
+
+            var accumulators = new Dictionary<string, CellAccumulator>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var node in group)
+            {
+                var nodeKey = node.NodeId.ToKey();
+
+                if (!approximationResults.TryGetValue(nodeKey, out var approximationResult))
+                {
+                    throw new InvalidOperationException(
+                        $"Approximation result '{nodeKey}' was not found while building calling super-ranges.");
+                }
+
+                foreach (var cell in approximationResult.Cells)
+                {
+                    if (cell.Weight <= 0)
+                        continue;
+
+                    var token = cell.HandClass.ToEquilabToken();
+
+                    if (!accumulators.TryGetValue(token, out var accumulator))
+                    {
+                        accumulator = new CellAccumulator(cell.HandClass);
+                        accumulators[token] = accumulator;
+                    }
+
+                    accumulator.SumWeights += cell.Weight;
+                    accumulator.SumContributionCombos += cell.HandClass.ComboCount * cell.Weight;
+                }
+            }
+
+            var weightedCells = accumulators.Values
+                .Select(a => new RangeCell(
+                    HandClass: a.HandClass,
+                    Weight: a.SumWeights / sourceRangeCount))
+                .Where(c => c.Weight > 0)
+                .OrderByDescending(c => c.Weight)
+                .ThenBy(c => c.HandClass.ToEquilabToken(), StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var totalContributionCombos = accumulators.Values.Sum(a => a.SumContributionCombos);
+            var averageCombosPerSourceRange = sourceRangeCount == 0
+                ? 0
+                : totalContributionCombos / sourceRangeCount;
+
+            var key = $"call_super_vs_{openPosition}";
+
+            results[key] = new WeightedSuperRangeResult(
+                Key: key,
+                OpenPosition: openPosition,
+                SourceRangeCount: sourceRangeCount,
+                TotalContributionCombos: totalContributionCombos,
+                AverageCombosPerSourceRange: averageCombosPerSourceRange,
+                Cells: weightedCells);
+        }
+
+        return results;
+    }
+
+    private static bool IsCallVsOpenNode(PopulationNode node)
+    {
+        ArgumentNullException.ThrowIfNull(node);
+
+        var nodeId = node.NodeId;
+
+        if (!NodeSpotHelper.IsCallAction(nodeId))
+            return false;
+
+        if (string.IsNullOrWhiteSpace(nodeId.Opponent))
+            return false;
+
+        if (NodeSpotHelper.IsVsThreeBetSpot(nodeId))
+            return false;
+
+        return true;
+    }
+
+    private static string NormalizeOpponent(string opponent)
+    {
+        return opponent.Trim().ToLowerInvariant();
+    }
+
+    private sealed class CellAccumulator
+    {
+        public CellAccumulator(HandClass handClass)
+        {
+            HandClass = handClass;
+        }
+
+        public HandClass HandClass { get; }
+
+        public double SumWeights { get; set; }
+
+        public double SumContributionCombos { get; set; }
+    }
+}

--- a/src/Poker.RangeApprox.Core/Approximation/WeightedSuperRangeResult.cs
+++ b/src/Poker.RangeApprox.Core/Approximation/WeightedSuperRangeResult.cs
@@ -1,0 +1,12 @@
+﻿using Poker.RangeApprox.Core.Domain;
+
+namespace Poker.RangeApprox.Core.Approximation;
+
+public sealed record WeightedSuperRangeResult(
+    string Key,
+    string OpenPosition,
+    int SourceRangeCount,
+    double TotalContributionCombos,
+    double AverageCombosPerSourceRange,
+    IReadOnlyList<RangeCell> Cells
+);

--- a/src/Poker.RangeApprox.Core/Formatting/EquilabFormatter.cs
+++ b/src/Poker.RangeApprox.Core/Formatting/EquilabFormatter.cs
@@ -6,8 +6,13 @@ public static class EquilabFormatter
 {
     public static string FormatExplicit(IReadOnlyList<RangeCell> cells)
     {
+        return FormatExplicit(cells, minimumWeight: 0.0);
+    }
+
+    public static string FormatExplicit(IReadOnlyList<RangeCell> cells, double minimumWeight)
+    {
         return string.Join(",", cells
-            .Where(c => c.Weight > 0)
+            .Where(c => c.Weight > minimumWeight)
             .Select(c => c.HandClass.ToEquilabToken()));
     }
 }

--- a/src/Poker.RangeApprox.Infrastructure/Writing/WeightedSuperRangeFileWriter.cs
+++ b/src/Poker.RangeApprox.Infrastructure/Writing/WeightedSuperRangeFileWriter.cs
@@ -1,0 +1,46 @@
+﻿using Poker.RangeApprox.Core.Approximation;
+
+namespace Poker.RangeApprox.Infrastructure.Writing;
+
+public sealed class WeightedSuperRangeFileWriter
+{
+    private readonly RangeFileWriter _rangeFileWriter;
+
+    public WeightedSuperRangeFileWriter(RangeFileWriter rangeFileWriter)
+    {
+        _rangeFileWriter = rangeFileWriter ?? throw new ArgumentNullException(nameof(rangeFileWriter));
+    }
+
+    public void WriteAll(
+        string outputRoot,
+        IReadOnlyDictionary<string, WeightedSuperRangeResult> superRanges)
+    {
+        ArgumentNullException.ThrowIfNull(outputRoot);
+        ArgumentNullException.ThrowIfNull(superRanges);
+
+        var baseDirectory = Path.Combine(outputRoot, "calling super-ranges");
+
+        foreach (var superRange in superRanges.Values.OrderBy(x => x.OpenPosition, StringComparer.OrdinalIgnoreCase))
+        {
+            var matrixPath = Path.Combine(baseDirectory, $"{superRange.Key}.matrix.txt");
+            var equilabPath = Path.Combine(baseDirectory, $"{superRange.Key}.txt");
+            var summaryPath = Path.Combine(baseDirectory, $"{superRange.Key}.summary.txt");
+
+            _rangeFileWriter.WriteMatrix(matrixPath, superRange.Cells);
+            _rangeFileWriter.WriteEquilab(equilabPath, superRange.Cells);
+
+            File.WriteAllText(summaryPath, BuildSummary(superRange));
+        }
+    }
+    private static string BuildSummary(WeightedSuperRangeResult result)
+    {
+        return $"""
+Key:                         {result.Key}
+Open Position:               {result.OpenPosition}
+Source Range Count:          {result.SourceRangeCount}
+Total Contribution Combos:   {result.TotalContributionCombos:0.###}
+Average Combos Per Range:    {result.AverageCombosPerSourceRange:0.###}
+""";
+    }
+
+}

--- a/tests/Poker.RangeApprox.Tests/Approximation/CallingSuperRangeBuilderTests.cs
+++ b/tests/Poker.RangeApprox.Tests/Approximation/CallingSuperRangeBuilderTests.cs
@@ -1,0 +1,152 @@
+﻿using NUnit.Framework;
+using Poker.RangeApprox.Core.Approximation;
+using Poker.RangeApprox.Core.Domain;
+
+namespace Poker.RangeApprox.Tests.Approximation;
+
+[TestFixture]
+public class CallingSuperRangeBuilderTests
+{
+    [Test]
+    public void Build_GroupsCallVsOpenNodes_ByOpenPosition()
+    {
+        var builder = new CallingSuperRangeBuilder();
+
+        var nodes = new List<PopulationNode>
+        {
+            new(new NodeId("call", "btn", "co"), 10),
+            new(new NodeId("call", "sb", "co"), 12),
+            new(new NodeId("call", "bb", "lj"), 8)
+        };
+
+        var results = new Dictionary<string, ApproximationResult>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["call_btn_vs_co"] = CreateResult("AKo"),
+            ["call_sb_vs_co"] = CreateResult("AQs"),
+            ["call_bb_vs_lj"] = CreateResult("KQs")
+        };
+
+        var superRanges = builder.Build(nodes, results);
+
+        Assert.That(superRanges.Count, Is.EqualTo(2));
+        Assert.That(superRanges.ContainsKey("call_super_vs_co"), Is.True);
+        Assert.That(superRanges.ContainsKey("call_super_vs_lj"), Is.True);
+    }
+
+    [Test]
+    public void Build_IgnoresCallVsThreeBetNodes()
+    {
+        var builder = new CallingSuperRangeBuilder();
+
+        var nodes = new List<PopulationNode>
+        {
+            new(new NodeId("call", "btn", "co"), 10),
+            new(new NodeId("call", "btn", "3bet_sb"), 40)
+        };
+
+        var results = new Dictionary<string, ApproximationResult>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["call_btn_vs_co"] = CreateResult("AKo"),
+            ["call_btn_vs_3bet_sb"] = CreateResult("72o")
+        };
+
+        var superRanges = builder.Build(nodes, results);
+
+        Assert.That(superRanges.Count, Is.EqualTo(1));
+        Assert.That(superRanges.ContainsKey("call_super_vs_co"), Is.True);
+        Assert.That(superRanges.ContainsKey("call_super_vs_3bet_sb"), Is.False);
+    }
+
+    [Test]
+    public void Build_AveragesWeightsAcrossSourceRanges()
+    {
+        var builder = new CallingSuperRangeBuilder();
+
+        var nodes = new List<PopulationNode>
+        {
+            new(new NodeId("call", "btn", "co"), 10),
+            new(new NodeId("call", "sb", "co"), 12)
+        };
+
+        var results = new Dictionary<string, ApproximationResult>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["call_btn_vs_co"] = CreateResult("AKo", "AQs"),
+            ["call_sb_vs_co"] = CreateResult("AKo", "KQs")
+        };
+
+        var superRanges = builder.Build(nodes, results);
+        var superRange = superRanges["call_super_vs_co"];
+
+        var weights = superRange.Cells.ToDictionary(
+            c => c.HandClass.ToEquilabToken(),
+            c => c.Weight,
+            StringComparer.OrdinalIgnoreCase);
+
+        Assert.That(superRange.SourceRangeCount, Is.EqualTo(2));
+
+        Assert.That(weights["AKo"], Is.EqualTo(1.0).Within(0.001));
+        Assert.That(weights["AQs"], Is.EqualTo(0.5).Within(0.001));
+        Assert.That(weights["KQs"], Is.EqualTo(0.5).Within(0.001));
+    }
+
+    [Test]
+    public void Build_ComputesContributionCombosCorrectly()
+    {
+        var builder = new CallingSuperRangeBuilder();
+
+        var nodes = new List<PopulationNode>
+        {
+            new(new NodeId("call", "btn", "co"), 10),
+            new(new NodeId("call", "sb", "co"), 12)
+        };
+
+        var results = new Dictionary<string, ApproximationResult>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["call_btn_vs_co"] = CreateResult("AKo", "AQs"),
+            ["call_sb_vs_co"] = CreateResult("AKo", "KQs")
+        };
+
+        var superRanges = builder.Build(nodes, results);
+        var superRange = superRanges["call_super_vs_co"];
+
+        // AKo = 12 combos in btn range + 12 combos in sb range = 24
+        // AQs = 4 combos
+        // KQs = 4 combos
+        // Total = 32
+        Assert.That(superRange.TotalContributionCombos, Is.EqualTo(32.0).Within(0.001));
+
+        // 32 / 2 source ranges = 16 average combos per source range
+        Assert.That(superRange.AverageCombosPerSourceRange, Is.EqualTo(16.0).Within(0.001));
+    }
+
+    [Test]
+    public void Build_ThrowsWhenSourceNodeResultIsMissing()
+    {
+        var builder = new CallingSuperRangeBuilder();
+
+        var nodes = new List<PopulationNode>
+        {
+            new(new NodeId("call", "btn", "co"), 10)
+        };
+
+        var results = new Dictionary<string, ApproximationResult>(StringComparer.OrdinalIgnoreCase);
+
+        Assert.Throws<InvalidOperationException>(() => builder.Build(nodes, results));
+    }
+
+    private static ApproximationResult CreateResult(params string[] handTokens)
+    {
+        var cells = handTokens
+            .Select(t => new RangeCell(HandClass.ParseRankingToken(t), 1.0))
+            .ToList();
+
+        var actualCombos = cells.Sum(c => c.HandClass.ComboCount * c.Weight);
+
+        return new ApproximationResult(
+            TargetPercent: 0,
+            ActualPercent: 0,
+            TargetCombos: actualCombos,
+            ActualCombos: actualCombos,
+            Cells: cells);
+    }
+}


### PR DESCRIPTION
Introduce building and output of weighted "calling super-ranges" for call-vs-open spots.

- Add CallingSuperRangeBuilder to aggregate call-vs-open PopulationNodes, average weights across source ranges, and compute combo contributions.
- Add WeightedSuperRangeResult record to represent a generated super-range.
- Add WeightedSuperRangeFileWriter to emit matrix, equilab and summary files for each super-range under output/calling super-ranges.
- Integrate builder/writer into Program.cs so super-ranges are generated and printed after per-node output; remove an unused using and tidy a formatting-if line.
- Adjust EquilabFormatter to support a minimumWeight filter (with a default overload) so writers can control which cells are included.
- Add comprehensive unit tests (CallingSuperRangeBuilderTests) covering grouping, ignoring 3bet spots, weight averaging, combo calculations, and missing-result errors.

These changes enable producing consolidated, weighted calling ranges for downstream analysis and output files.